### PR TITLE
add no_data argument to augment arg check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,4 +24,4 @@ Remotes:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1

--- a/R/check_arguments.R
+++ b/R/check_arguments.R
@@ -1,6 +1,7 @@
 #' Check that tidying methods use allowed argument names
 #'
 #' @param tidy_method A tidying method. For example: `glance.Arima`.
+#' @param no_data Logical. Override strict requirement that `augment` methods need `data` argument?
 #' @template boilerplate
 #'
 #' @description Tests when `strict = FALSE`:
@@ -19,7 +20,7 @@
 #' @seealso [testthat], [testthat::expect_true()]
 #' @export
 #'
-check_arguments <- function(tidy_method, strict = TRUE) {
+check_arguments <- function(tidy_method, strict = TRUE, no_data = FALSE) {
 
   if (!strict) {
     expect_true(TRUE)  # prevent skip message
@@ -72,7 +73,7 @@ check_arguments <- function(tidy_method, strict = TRUE) {
     )
   }
 
-  if (prefix == "augment") {
+  if (!no_data & prefix == "augment") {
     expect_true(
       "data" %in% args,
       info = "Augment methods must have a `data` argument."

--- a/man/check_arguments.Rd
+++ b/man/check_arguments.Rd
@@ -4,13 +4,15 @@
 \alias{check_arguments}
 \title{Check that tidying methods use allowed argument names}
 \usage{
-check_arguments(tidy_method, strict = TRUE)
+check_arguments(tidy_method, strict = TRUE, no_data = FALSE)
 }
 \arguments{
 \item{tidy_method}{A tidying method. For example: \code{glance.Arima}.}
 
 \item{strict}{Logical indicating whether the strict version of tests should be used. Defaults
 to \code{TRUE}.}
+
+\item{no_data}{Logical. Override strict requirement that \code{augment} methods need \code{data} argument?}
 }
 \value{
 An invisible \code{NULL}. This function should be called for side effects, not return values.
@@ -27,6 +29,10 @@ Tests when \code{strict = FALSE}:
 Tests when \code{strict = TRUE}:
 \itemize{
 \item \code{tidy_method} has a \code{conf.int} argument if it has a \code{conf.level} argument.
+\item \code{tidy_method} has a \code{conf.level} argument if it has a \code{conf.int} argument.
+\item \code{conf.int} defaults to \code{FALSE} when present.
+\item \code{conf.level} defaults to `0.95`` when present.
+\item \code{exponentiate} defaults to \code{FALSE} when present.
 \item All arguments to \code{tidy_method} are listed in the \link{argument_glossary}.
 }
 }

--- a/modeltests.Rproj
+++ b/modeltests.Rproj
@@ -18,3 +18,4 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
`check_arguments` checks that `augment` methods have a `data` argument when `strict = TRUE`, but as discussed in softloud/metabroom#15, `rma` methods don't use data. This PR adds an argument to override the `data` requirement for `augment` while keeping other strict requirements. I'm not sure if this is the best approach (vs. deleting that requirement), but let me know what you think.

Also addresses a test result in tidymodels/broom#674