### PR TITLE
Add `within.r.squared` term

### DIFF
--- a/data-raw/columns_glance.yaml
+++ b/data-raw/columns_glance.yaml
@@ -132,3 +132,4 @@ total: total number of person-years tabulated
 total.variance: Total cumulative proportion of variance accounted for by all factors
 totss: The total sum of squares
 value: minimized or maximized output value
+within.r.squared: R squared within fixed-effect groups


### PR DESCRIPTION
The `within.r.squared` is the R2 within fixed-effect groups. That is, the R2 of the within estimator, the fraction of variance explained after removing differences in group averages.

Let me know if this is too niche to be included in the glance column list.