### PR TITLE
0.1.2 CRAN Release

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@
 ^\.Rproj\.user$
 ^cran-comments.md$
 ^CRAN-RELEASE$
+revdep/

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,0 @@
-This package was submitted to CRAN on 2020-01-27.
-Once it is accepted, delete this file and tag the release (commit e845670d49).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: modeltests
 Title: Testing Infrastructure for Broom Model Generics
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: 
     person(given = "Alex",
            family = "Hayes",
@@ -29,4 +29,4 @@ Suggests:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # modeltests 0.1.2
 
-* Extended the argument and column glossaries to accomodate changes in
+* Extended the argument and column glossaries to accommodate changes in
 the upcoming broom release.
 
 # modeltests 0.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# modeltests 0.1.2
+
+* Extended the argument and column glossaries to accomodate changes in
+the upcoming broom release.
+
+# modeltests 0.1.1
+
+* Fixes for tibble 3.0.0
+
 # modeltests 0.1.0
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,7 @@
 ## modeltests
 
 This submission extends the argument and column glossaries used for unit
-testing in modeling packages to accomodate the upcoming broom release.
+testing in modeling packages to accommodate the upcoming broom release.
 
 ## Test environments
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,13 +1,20 @@
 ## modeltests
 
-This submission fixes failures due to changes to the `tibble` package associated with the 3.0.0 release
+This submission extends the argument and column glossaries used for unit
+testing in modeling packages to accomodate the upcoming broom release.
 
 ## Test environments
 
-* local Windows 8 install: R 3.6
+* local OS X install: R 3.6
 * win-builder: oldrel, rel, devel
 * rhub: oldrel, rel, devel
 
 ## R CMD check results
 
 There were no ERRORs, WARNINGs or NOTEs.
+
+## Downstream dependencies
+
+I have also run R CMD check on the one downstream dependency of modeltests,
+ItemResponseTrees, and the package passes with no ERRORs, WARNINGs, or
+NOTEs.

--- a/man/argument_glossary.Rd
+++ b/man/argument_glossary.Rd
@@ -4,12 +4,14 @@
 \name{argument_glossary}
 \alias{argument_glossary}
 \title{Allowed argument names in tidiers}
-\format{A tibble with 3 variables:
+\format{
+A tibble with 3 variables:
 \describe{
 \item{method}{One of "glance", "augment" or "tidy".}
 \item{argument}{Character name of allowed argument name.}
 \item{description}{Character description of argument use.}
-}}
+}
+}
 \usage{
 argument_glossary
 }

--- a/man/check_augment_data_specification.Rd
+++ b/man/check_augment_data_specification.Rd
@@ -4,8 +4,7 @@
 \alias{check_augment_data_specification}
 \title{Check that augment behavior is consistent for dataframes and tibbles}
 \usage{
-check_augment_data_specification(aug, model, data, add_missing,
-  test_newdata)
+check_augment_data_specification(aug, model, data, add_missing, test_newdata)
 }
 \arguments{
 \item{aug}{An augment method. For example, \code{augment.betareg}.}

--- a/man/check_augment_function.Rd
+++ b/man/check_augment_function.Rd
@@ -4,8 +4,7 @@
 \alias{check_augment_function}
 \title{Check an augment method}
 \usage{
-check_augment_function(aug, model, data = NULL, newdata = NULL,
-  strict = TRUE)
+check_augment_function(aug, model, data = NULL, newdata = NULL, strict = TRUE)
 }
 \arguments{
 \item{aug}{An augment method. For example, \code{augment.betareg}.}

--- a/man/check_single_augment_output.Rd
+++ b/man/check_single_augment_output.Rd
@@ -4,8 +4,7 @@
 \alias{check_single_augment_output}
 \title{Check the output of an augment method}
 \usage{
-check_single_augment_output(au, passed_data, model = NULL,
-  strict = TRUE)
+check_single_augment_output(au, passed_data, model = NULL, strict = TRUE)
 }
 \arguments{
 \item{au}{Output from a call to \code{\link[=augment]{augment()}}.}

--- a/man/column_glossary.Rd
+++ b/man/column_glossary.Rd
@@ -4,12 +4,14 @@
 \name{column_glossary}
 \alias{column_glossary}
 \title{Allowed column names in tidied tibbles}
-\format{A tibble with 4 variables:
+\format{
+A tibble with 4 variables:
 \describe{
 \item{method}{One of "glance", "augment" or "tidy".}
 \item{column}{Character name of allowed output column.}
 \item{description}{Character description of expected column contents.}
-}}
+}
+}
 \usage{
 column_glossary
 }

--- a/man/modeltests-package.Rd
+++ b/man/modeltests-package.Rd
@@ -21,7 +21,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Alex Hayes \email{alexpghayes@gmail.com} (0000-0002-4985-5160)
+\strong{Maintainer}: Alex Hayes \email{alexpghayes@gmail.com} (\href{https://orcid.org/0000-0002-4985-5160}{ORCID})
 
 }
 \keyword{internal}

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,0 +1,56 @@
+# Platform
+
+|field    |value                        |
+|:--------|:----------------------------|
+|version  |R version 3.6.3 (2020-02-29) |
+|os       |macOS Catalina 10.15.4       |
+|system   |x86_64, darwin15.6.0         |
+|ui       |RStudio                      |
+|language |(EN)                         |
+|collate  |en_US.UTF-8                  |
+|ctype    |en_US.UTF-8                  |
+|tz       |America/Los_Angeles          |
+|date     |2020-06-02                   |
+
+# Dependencies
+
+|package     |old    |new    |Δ  |
+|:-----------|:------|:------|:--|
+|modeltests  |0.1.1  |0.1.1  |NA |
+|assertthat  |0.2.1  |0.2.1  |NA |
+|backports   |1.1.7  |1.1.7  |NA |
+|callr       |3.4.3  |3.4.3  |NA |
+|cli         |2.0.2  |2.0.2  |NA |
+|crayon      |1.3.4  |1.3.4  |NA |
+|desc        |1.2.0  |1.2.0  |NA |
+|digest      |0.6.25 |0.6.25 |NA |
+|dplyr       |1.0.0  |1.0.0  |NA |
+|ellipsis    |0.3.1  |0.3.1  |NA |
+|evaluate    |0.14   |0.14   |NA |
+|fansi       |0.4.1  |0.4.1  |NA |
+|generics    |0.0.2  |0.0.2  |NA |
+|glue        |1.4.1  |1.4.1  |NA |
+|lifecycle   |0.2.0  |0.2.0  |NA |
+|magrittr    |1.5    |1.5    |NA |
+|pillar      |1.4.4  |1.4.4  |NA |
+|pkgbuild    |1.0.8  |1.0.8  |NA |
+|pkgconfig   |2.0.3  |2.0.3  |NA |
+|pkgload     |1.1.0  |1.1.0  |NA |
+|praise      |1.0.0  |1.0.0  |NA |
+|prettyunits |1.1.1  |1.1.1  |NA |
+|processx    |3.4.2  |3.4.2  |NA |
+|ps          |1.3.3  |1.3.3  |NA |
+|purrr       |0.3.4  |0.3.4  |NA |
+|R6          |2.4.1  |2.4.1  |NA |
+|rlang       |0.4.6  |0.4.6  |NA |
+|rprojroot   |1.3-2  |1.3-2  |NA |
+|rstudioapi  |0.11   |0.11   |NA |
+|testthat    |2.3.2  |2.3.2  |NA |
+|tibble      |3.0.1  |3.0.1  |NA |
+|tidyselect  |1.1.0  |1.1.0  |NA |
+|utf8        |1.1.4  |1.1.4  |NA |
+|vctrs       |0.3.0  |0.3.0  |NA |
+|withr       |2.2.0  |2.2.0  |NA |
+
+# Revdeps
+

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -1,0 +1,1 @@
+*Wow, no problems at all. :)*

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -1,0 +1,1 @@
+*Wow, no problems at all. :)*


### PR DESCRIPTION
Some documentation and metadata updates for the next release of modeltests with updates to the column and argument glossaries to accommodate the upcoming broom release. Reverse dependencies are all passing. I'm unable to check on r-hub and winbuilder myself since I'm not the maintainer, but otherwise, metadata should be good to go. I'm glad to make edits if issues come up with either of those checks.🙂